### PR TITLE
Fix Python 2 Syntax Error

### DIFF
--- a/solver.py
+++ b/solver.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F


### PR DESCRIPTION
flake8 testing of https://github.com/yunjey/StarGAN on Python 2.7.14

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__

```
./solver.py:281:90: E999 SyntaxError: invalid syntax
                        print('Classification Acc (Black/Blond/Brown/Gender/Aged): ', end='')
                                                                                         ^
```