### PR TITLE
Disable tensorflow v2 behavior in logger.py

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -1,5 +1,6 @@
-import tensorflow as tf
-
+#import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 
 class Logger(object):
     """Tensorboard logger."""


### PR DESCRIPTION
Tensorflow version 2 does not use ```FileWriter```. This code is based on tensorflow version 1 so if we want to use the original code, we need to apply this commit (just disable tensorflow v2 behavior, use tensorflow v1) 